### PR TITLE
Add .gitignore for kotoba config/cache protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+"addons/kotoba/translator_config.txt"  
+"addons/kotoba/translations.db"  
+"addons/kotoba/__pycache__/"  
+"addons/kotoba/translator_config.txt"  
+"addons/kotoba/translations.db"  
+"addons/kotoba/__pycache__/"  


### PR DESCRIPTION
Prevents API keys in translator_config.txt and translations.db from being committed.