### PR TITLE
Harden Kotoba cache and keep API keys out of git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Kotoba secrets + runtime artifacts
+Ashita/addons/kotoba/translator_config.txt
+Ashita/addons/kotoba/translations.db
+Ashita/addons/kotoba/translation_queue.txt
+Ashita/addons/kotoba/translation_results.txt
+Ashita/addons/kotoba/heartbeat.txt
+Ashita/addons/kotoba/debug.log
+Ashita/addons/kotoba/suggested_terms.log
+Ashita/addons/kotoba/.codegraph/

--- a/Ashita/addons/kotoba/README.md
+++ b/Ashita/addons/kotoba/README.md
@@ -14,8 +14,8 @@ Kotoba is an Ashita addon that automatically translates Japanese messages in FFX
 - ✅ **Casual Tone** - "ソーティやる？" → "Wanna do Sortie?" (not stiff formal translation)
 - ✅ **Community Glossary** - Add your own terms in `ffxi_glossary.txt` (hot-reloads!)
 - ✅ **Smart Detection** - Automatically suggests missing glossary terms
-- ✅ **SQLite Durable Cache** - `translations.db` stores every translation for instant retrieval, even after restarts
-- ✅ **Warm Cache Seeding** - Run `build_seed_db.py` to pre-load common phrases on first run
+- ✅ **SQLite Durable Cache** - `translations.db` stores every translation for instant retrieval, even after restarts (normalized keys so `！`/`?` variants share hits)
+- ✅ **Warm Cache Seeding** - Run `build_seed_db.py` to pre-load common *full chat phrases* (glossary stays for preprocess only)
 - ✅ **Stats Tracking** - See cache hit rates, glossary usage, and more
 - ✅ **Non-Blocking** - Never freezes the game
 - ✅ **Reliable** - File-based system is bulletproof
@@ -28,15 +28,19 @@ Kotoba is an Ashita addon that automatically translates Japanese messages in FFX
 2. Double-click **`install.bat`** — installs Python dependencies (`httpx`) and sets up the environment
 
 ### Step 2: Configure LLM API Key
-1. Open `C:\Ashita\addons\kotoba\translator_config.txt`
-2. Replace `YOUR_API_KEY_HERE` with your actual API key (DeepSeek, OpenAI, or any OpenAI-compatible provider)
-3. Set the API base URL and model name to match your provider (e.g. DeepSeek, OpenAI, or a local Ollama endpoint)
+1. Copy the example config (install.bat does this automatically if missing):
+   ```
+   copy translator_config.example.txt translator_config.txt
+   ```
+2. Open `translator_config.txt` and replace `your_api_key_here` with your API key
+3. Set the API base URL and model name to match your provider (DeepSeek, OpenAI, OpenRouter, Ollama, etc.)
+4. `translator_config.txt` is gitignored — never commit keys
 
-### Step 3: Start the Translator Service
-1. Double-click **`start_translator.bat`**
-2. First run will auto-install `httpx` and build the seed database (`translations.db`) via `build_seed_db.py`
-3. Leave the window open while playing FFXI
-4. You'll see a fancy startup banner! 🌸
+### Step 3: Start Translating
+1. In FFXI: `/addon load kotoba` — the addon **auto-starts** the translator headlessly (`pythonw`)
+2. Optional: double-click **`start_translator.bat`** if you want a visible console / manual start
+3. When you leave the game (heartbeat goes stale ~30s), the translator **auto-shuts down**
+4. First run builds the seed database (`translations.db`) via `build_seed_db.py` if missing
 
 ### Step 4: Use Kotoba In-Game
 ```

--- a/Ashita/addons/kotoba/build_seed_db.py
+++ b/Ashita/addons/kotoba/build_seed_db.py
@@ -1,19 +1,55 @@
 #!/usr/bin/env python3
 """
 Kotoba Seed Database Builder
-Reads ffxi_glossary.txt and pre-baked common phrases to populate translations.db
-with a warm cache. Run once on install or when you want to rebuild the cache.
+Pre-loads translations.db with common *full chat phrases* for a warm cache.
+
+Glossary terms (ffxi_glossary.txt) are intentionally NOT seeded here — they are
+word/phrase fragments used during preprocess, not complete chat messages. Seeding
+them as full-message translations caused odd hits when someone typed just a term.
 """
 
+import re
 import sqlite3
 import time
+import unicodedata
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).parent
 DB_FILE = SCRIPT_DIR / "translations.db"
-GLOSSARY_FILE = SCRIPT_DIR / "ffxi_glossary.txt"
 
-# Pre-baked common FFXI phrases (JP -> EN)
+# Punctuation / whitespace variants that should share a cache entry
+_PUNCT_MAP = str.maketrans({
+    '！': '!',
+    '？': '?',
+    '。': '.',
+    '、': ',',
+    '｡': '.',
+    '､': ',',
+    '･': '・',
+    '～': '~',
+    '〜': '~',
+    '―': '-',
+    '‐': '-',
+    '‑': '-',
+    '–': '-',
+    '—': '-',
+    '　': ' ',
+    '\u200b': '',
+    '\ufeff': '',
+})
+
+
+def normalize_cache_key(text):
+    """Same normalization as translator.py so seeds hit at runtime."""
+    if not text:
+        return ''
+    text = unicodedata.normalize('NFKC', text)
+    text = text.translate(_PUNCT_MAP)
+    text = re.sub(r'\s+', ' ', text).strip()
+    return text
+
+
+# Pre-baked common FFXI phrases (JP -> EN) — full messages only
 SEED_PHRASES = {
     # Greetings
     "こんにちは": "hi",
@@ -180,61 +216,33 @@ def init_db(conn):
     conn.commit()
 
 
-def load_glossary_file():
-    """Load JP|EN pairs from ffxi_glossary.txt"""
-    terms = {}
-    if not GLOSSARY_FILE.exists():
-        print(f"[Seed DB] Glossary file not found: {GLOSSARY_FILE}")
-        return terms
-
-    with open(GLOSSARY_FILE, 'r', encoding='utf-8') as f:
-        for line_num, line in enumerate(f, 1):
-            line = line.strip()
-            if not line or line.startswith('#'):
-                continue
-            if '|' in line:
-                parts = line.split('|', 1)
-                if len(parts) == 2:
-                    jp, en = parts[0].strip(), parts[1].strip()
-                    if jp and en:
-                        terms[jp] = en
-    return terms
-
-
 def main():
     print("\n" + "=" * 60)
     print("  KOTOBA SEED DATABASE BUILDER")
     print("=" * 60)
+    print("[Seed DB] Glossary terms are NOT seeded as full-message cache")
+    print("[Seed DB] entries (they stay in preprocess via ffxi_glossary.txt).")
 
     conn = sqlite3.connect(str(DB_FILE))
     init_db(conn)
 
     now = time.time()
 
-    # 1. Load glossary file terms
-    glossary_terms = load_glossary_file()
-    print(f"[Seed DB] Loaded {len(glossary_terms)} terms from {GLOSSARY_FILE.name}")
-
-    glossary_added = 0
-    for jp, en in glossary_terms.items():
-        cursor = conn.execute(
-            "INSERT OR IGNORE INTO translations (source_text, source_lang, target_lang, translated_text, usage_count, last_used, created_at) VALUES (?, 'ja', 'en', ?, 0, ?, ?)",
-            (jp, en, now, now)
-        )
-        if cursor.rowcount > 0:
-            glossary_added += 1
-
-    conn.commit()
-    print(f"[Seed DB] Added {glossary_added} glossary terms")
-
-    # 2. Insert pre-baked seed phrases
+    # Insert pre-baked full-message seed phrases (normalized keys)
     print(f"[Seed DB] Inserting {len(SEED_PHRASES)} pre-baked common phrases")
     phrase_added = 0
+    seen_keys = set()
 
     for jp, en in SEED_PHRASES.items():
+        key = normalize_cache_key(jp)
+        if not key or key in seen_keys:
+            continue
+        seen_keys.add(key)
         cursor = conn.execute(
-            "INSERT OR IGNORE INTO translations (source_text, source_lang, target_lang, translated_text, usage_count, last_used, created_at) VALUES (?, 'ja', 'en', ?, 0, ?, ?)",
-            (jp, en, now, now)
+            "INSERT OR IGNORE INTO translations "
+            "(source_text, source_lang, target_lang, translated_text, usage_count, last_used, created_at) "
+            "VALUES (?, 'ja', 'en', ?, 0, ?, ?)",
+            (key, en, now, now)
         )
         if cursor.rowcount > 0:
             phrase_added += 1
@@ -242,7 +250,6 @@ def main():
     conn.commit()
     print(f"[Seed DB] Added {phrase_added} pre-baked phrases")
 
-    # Final count
     total = conn.execute("SELECT COUNT(*) FROM translations").fetchone()[0]
     conn.close()
 

--- a/Ashita/addons/kotoba/install.bat
+++ b/Ashita/addons/kotoba/install.bat
@@ -31,13 +31,19 @@ if errorlevel 1 (
 )
 echo.
 
-REM Create config template if not exists
+REM Create config from example if not exists
 echo [3/4] Checking config...
 if not exist "translator_config.txt" (
-    echo LLM_API_KEY=your_api_key_here> translator_config.txt
-    echo LLM_BASE_URL=https://api.deepseek.com/v1>> translator_config.txt
-    echo LLM_MODEL=deepseek-chat>> translator_config.txt
-    echo   Created translator_config.txt
+    if exist "translator_config.example.txt" (
+        copy /Y "translator_config.example.txt" "translator_config.txt" >nul
+        echo   Created translator_config.txt from example.
+    ) else (
+        echo LLM_API_KEY=your_api_key_here> translator_config.txt
+        echo LLM_BASE_URL=https://api.deepseek.com/v1>> translator_config.txt
+        echo LLM_MODEL=deepseek-chat>> translator_config.txt
+        echo   Created translator_config.txt
+    )
+    echo   Edit translator_config.txt and add your LLM API key before starting.
 ) else (
     echo   translator_config.txt already exists.
 )

--- a/Ashita/addons/kotoba/translator.py
+++ b/Ashita/addons/kotoba/translator.py
@@ -23,6 +23,7 @@ import time
 import sys
 import re
 import sqlite3
+import unicodedata
 from pathlib import Path
 from datetime import datetime
 
@@ -59,10 +60,22 @@ def load_config():
     """Load LLM configuration from translator_config.txt"""
     global LLM_API_KEY, LLM_BASE_URL, LLM_MODEL
 
+    example = SCRIPT_DIR / "translator_config.example.txt"
     if not CONFIG_FILE.exists():
         print(f"[Kotoba Translator] ERROR: Config file not found: {CONFIG_FILE}")
-        print(f"[Kotoba Translator] Create it with: LLM_API_KEY=your_key_here")
+        if example.exists():
+            print(f"[Kotoba Translator] Copy the example and add your key:")
+            print(f"[Kotoba Translator]   copy {example.name} {CONFIG_FILE.name}")
+        else:
+            print(f"[Kotoba Translator] Create it with: LLM_API_KEY=your_key_here")
         sys.exit(1)
+
+    placeholder_keys = {
+        'your_api_key_here',
+        'INSERT_YOUR_API_KEY_HERE',
+        'YOUR_API_KEY_HERE',
+        'sk-or-v1-REPLACE_ME',
+    }
 
     try:
         with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
@@ -81,7 +94,7 @@ def load_config():
                     elif key == 'LLM_MODEL':
                         LLM_MODEL = value
 
-        if not LLM_API_KEY or LLM_API_KEY in ('your_api_key_here', 'INSERT_YOUR_API_KEY_HERE'):
+        if not LLM_API_KEY or LLM_API_KEY in placeholder_keys:
             print("[Kotoba Translator] ERROR: LLM_API_KEY not set in config")
             print(f"[Kotoba Translator] Edit: {CONFIG_FILE}")
             sys.exit(1)
@@ -128,6 +141,42 @@ Assistant: Haste pls"""
 # SQLITE CACHE
 # ============================================================================
 
+# Punctuation / whitespace variants that should share a cache entry
+_PUNCT_MAP = str.maketrans({
+    '！': '!',
+    '？': '?',
+    '。': '.',
+    '、': ',',
+    '｡': '.',
+    '､': ',',
+    '･': '・',
+    '～': '~',
+    '〜': '~',
+    '―': '-',
+    '‐': '-',
+    '‑': '-',
+    '–': '-',
+    '—': '-',
+    '　': ' ',  # ideographic space
+    '\u200b': '',  # zero-width space
+    '\ufeff': '',  # BOM
+})
+
+
+def normalize_cache_key(text):
+    """Normalize text so trivial variants hit the same cache entry.
+
+    Handles fullwidth/halfwidth (NFKC), JP/EN punctuation variants,
+    and collapsed whitespace — without changing Japanese word content.
+    """
+    if not text:
+        return ''
+    text = unicodedata.normalize('NFKC', text)
+    text = text.translate(_PUNCT_MAP)
+    text = re.sub(r'\s+', ' ', text).strip()
+    return text
+
+
 def init_db():
     """Initialize SQLite database and create tables if needed."""
     conn = sqlite3.connect(str(DB_FILE))
@@ -145,23 +194,80 @@ def init_db():
     """)
     conn.execute("CREATE INDEX IF NOT EXISTS idx_last_used ON translations(last_used)")
     conn.commit()
+    migrated = migrate_normalize_cache_keys(conn)
     conn.close()
     print(f"[Kotoba Translator] SQLite cache initialized: {DB_FILE}")
+    if migrated:
+        print(f"[Kotoba Translator] Migrated {migrated} cache key(s) to normalized form")
+
+
+def migrate_normalize_cache_keys(conn):
+    """Rewrite existing rows onto normalized keys; merge collisions by usage."""
+    rows = conn.execute(
+        "SELECT source_text, source_lang, target_lang, translated_text, "
+        "usage_count, last_used, created_at FROM translations"
+    ).fetchall()
+
+    changed = 0
+    for source_text, source_lang, target_lang, translated_text, usage_count, last_used, created_at in rows:
+        key = normalize_cache_key(source_text)
+        if key == source_text:
+            continue
+
+        changed += 1
+        conn.execute(
+            "DELETE FROM translations WHERE source_text=? AND source_lang=? AND target_lang=?",
+            (source_text, source_lang, target_lang)
+        )
+        existing = conn.execute(
+            "SELECT usage_count, last_used, created_at, translated_text "
+            "FROM translations WHERE source_text=? AND source_lang=? AND target_lang=?",
+            (key, source_lang, target_lang)
+        ).fetchone()
+
+        if existing:
+            old_usage, old_last, old_created, old_translated = existing
+            created_vals = [x for x in (old_created, created_at) if x is not None]
+            conn.execute(
+                "UPDATE translations SET usage_count=?, last_used=?, created_at=?, translated_text=? "
+                "WHERE source_text=? AND source_lang=? AND target_lang=?",
+                (
+                    (old_usage or 0) + (usage_count or 0),
+                    max(old_last or 0, last_used or 0),
+                    min(created_vals) if created_vals else None,
+                    # Prefer the more-used translation
+                    translated_text if (usage_count or 0) >= (old_usage or 0) else old_translated,
+                    key, source_lang, target_lang,
+                )
+            )
+        else:
+            conn.execute(
+                "INSERT INTO translations "
+                "(source_text, source_lang, target_lang, translated_text, usage_count, last_used, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (key, source_lang, target_lang, translated_text, usage_count or 0, last_used, created_at)
+            )
+
+    if changed:
+        conn.commit()
+    return changed
+
 
 def get_cached_translation(source_text, source_lang, target_lang):
     """Check SQLite cache for a translation. Returns (translation, hit_bool)."""
+    key = normalize_cache_key(source_text)
     conn = sqlite3.connect(str(DB_FILE))
     try:
         cursor = conn.execute(
             "SELECT translated_text FROM translations WHERE source_text=? AND source_lang=? AND target_lang=?",
-            (source_text, source_lang, target_lang)
+            (key, source_lang, target_lang)
         )
         row = cursor.fetchone()
         if row:
-            # Update usage stats
             conn.execute(
-                "UPDATE translations SET usage_count=usage_count+1, last_used=? WHERE source_text=? AND source_lang=? AND target_lang=?",
-                (time.time(), source_text, source_lang, target_lang)
+                "UPDATE translations SET usage_count=usage_count+1, last_used=? "
+                "WHERE source_text=? AND source_lang=? AND target_lang=?",
+                (time.time(), key, source_lang, target_lang)
             )
             conn.commit()
             return row[0], True
@@ -169,18 +275,28 @@ def get_cached_translation(source_text, source_lang, target_lang):
     finally:
         conn.close()
 
+
 def store_translation(source_text, source_lang, target_lang, translated_text):
-    """Store a translation in the SQLite cache."""
+    """Store a translation in the SQLite cache without resetting usage_count."""
+    key = normalize_cache_key(source_text)
     conn = sqlite3.connect(str(DB_FILE))
     try:
         now = time.time()
         conn.execute(
-            "INSERT OR REPLACE INTO translations (source_text, source_lang, target_lang, translated_text, usage_count, last_used, created_at) VALUES (?, ?, ?, ?, 1, ?, ?)",
-            (source_text, source_lang, target_lang, translated_text, now, now)
+            """
+            INSERT INTO translations
+                (source_text, source_lang, target_lang, translated_text, usage_count, last_used, created_at)
+            VALUES (?, ?, ?, ?, 1, ?, ?)
+            ON CONFLICT(source_text, source_lang, target_lang) DO UPDATE SET
+                translated_text = excluded.translated_text,
+                last_used = excluded.last_used
+            """,
+            (key, source_lang, target_lang, translated_text, now, now)
         )
         conn.commit()
     finally:
         conn.close()
+
 
 def get_cache_size():
     """Return the number of cached translations."""

--- a/Ashita/addons/kotoba/translator_config.example.txt
+++ b/Ashita/addons/kotoba/translator_config.example.txt
@@ -1,6 +1,11 @@
 # Kotoba Translator Configuration
 # LLM API settings (OpenAI-compatible)
-# Works with DeepSeek (default), OpenAI, or any OpenAI-compatible endpoint
+# Works with DeepSeek (default), OpenAI, OpenRouter, or any OpenAI-compatible endpoint
+#
+# Copy this file to translator_config.txt and add your key:
+#   copy translator_config.example.txt translator_config.txt
+#
+# Never commit translator_config.txt -- it is gitignored.
 
 LLM_API_KEY=your_api_key_here
 LLM_BASE_URL=https://api.deepseek.com/v1


### PR DESCRIPTION
## Summary
- Normalize SQLite cache keys (NFKC + punctuation/whitespace) so trivial JP/EN variants share hits, and migrate existing rows on startup
- Preserve `usage_count` on cache upsert instead of resetting via `INSERT OR REPLACE`
- Seed only full chat phrases (glossary stays preprocess-only); gitignore secrets/runtime artifacts and ship `translator_config.example.txt`

## Test plan
- [ ] Copy example config to `translator_config.txt`, set API key, run `build_seed_db.py` — expect ~123 phrases, no bare glossary terms like `ソーティ`
- [ ] Translate `おつかれ！` then `おつかれ!` — second should be a SQLite cache hit
- [ ] Confirm `usage_count` does not reset when the same key is re-stored
- [ ] `/addon load kotoba` auto-spawns translator; leave game ~30s and confirm auto-shutdown via heartbeat
- [ ] Confirm `translator_config.txt` is not staged/committed
